### PR TITLE
chore: add explicit least-privilege permissions to GitHub Actions

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -11,6 +11,9 @@ on:
       - 'flash-review-backend/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Build and Test


### PR DESCRIPTION
Adds explicit permissions blocks to all GitHub Actions workflow files that are missing them, following the principle of least privilege. This prevents workflows from having default write-all access to the GitHub token.